### PR TITLE
Overhaul get_model_vis.py

### DIFF
--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -70,5 +70,5 @@ if __name__ == "__main__":
                 data[bl] -= model[data_to_model_bl_map[bl]]
         hd.update(data=data)
         hd.phase_to_time(np.median(hd.time_array))
-        outname = os.path.basename(filename).replace('uvh5', f'{out}.uvfits')
+        outname = os.path.basename(a.filename).replace('uvh5', f'{out}.uvfits')
         hd.write_uvfits(os.path.join(a.outdir, outname), spoof_nonessential=True)

--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -64,8 +64,8 @@ if __name__ == "__main__":
 
     # update data to make model or residual, then write to disk
     for out in ['model', 'res']:
-        hd = HERAData(a.filename, times=data_times_to_load)
-        data, _, _ = hd.read(bls=data_bl_to_load)
+        hd = HERAData(a.filename)
+        data, _, _ = hd.read(bls=data_bl_to_load, times=data_times_to_load)
         lst_rephase(model, model_blvecs, model.freqs, data.lsts - model.lsts,
                     lat=hdm.telescope_location_lat_lon_alt_degrees[0], inplace=True)
         for bl in data:

--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -22,7 +22,13 @@ if __name__ == "__main__":
     # load filename metadata
     uvd = UVData()
     uvd.read(a.filename, read_data=True)
-    lst_bounds = [uvd.lst_array.min(), uvd.lst_array.max()]
+    dlst = np.median(np.diff(np.unwrap(np.unique(uvd.lst_array))))
+    lst_bounds = [uvd.lst_array.min() - dlst / 2, uvd.lst_array.max() + dlst / 2]
+    # handle branch cut appropriately
+    if lst_bounds[0] < 0:
+        lst_bounds[0] += 2*np.pi
+    if lst_bounds[1] > 2*np.pi:
+        lst_bounds[1] -= 2*np.pi
     if lst_bounds[1] < lst_bounds[0]:
         lst_bounds[1] += 2*np.pi
 
@@ -60,7 +66,7 @@ if __name__ == "__main__":
 
     # down select on lsts
     uvm_lsts = np.unwrap(np.unique(uvm.lst_array))
-    tinds = (uvm_lsts >= lst_bounds[0]) & (uvm_lsts <= lst_bounds[1])
+    tinds = (uvm_lsts > lst_bounds[0]) & (uvm_lsts < lst_bounds[1])
     uvm.select(times=np.unique(uvm.time_array)[tinds])
 
     # expand to data baselines

--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -55,13 +55,14 @@ if __name__ == "__main__":
      data_to_model_bl_map) = match_baselines(hd.bls, model_bls, hd.antpos, model_antpos=model_antpos, tol=1.0,
                                              data_is_redsol=False, model_is_redundant=(not a.model_not_redundant))
 
-    # load model (just the times of interest)
-    model_times_to_load = [d2m_time_map[time] for time in hd.times]
+    # load model (just the times of interest) and get times in data that have a corresponding time in the model
+    model_times_to_load = [d2m_time_map[time] for time in hd.times if d2m_time_map[time] is not None]
+    data_times_to_load = [time for time in hd.times if d2m_time_map[time] is not None]
     model, _, _ = partial_time_io(hdm, np.unique(model_times_to_load), bls=model_bl_to_load)
 
     # update data to make model or residual, then write to disk
     for out in ['model', 'res']:
-        hd = HERAData(a.filename)
+        hd = HERAData(a.filename, times=data_times_to_load)
         data, _, _ = hd.read(bls=data_bl_to_load)
         for bl in data:
             if out == 'model':

--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -78,7 +78,8 @@ if __name__ == "__main__":
                                           model_is_redundant=True)
 
     # construct model and residual
-    mod, res = copy.deepcopy(uvd), copy.deepcopy(uvd)
+    mod = uvd
+    res = copy.deepcopy(uvd)
     for blp in data_bls:
         # get indices in data
         bltinds = mod.antpair2ind(blp)

--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -71,4 +71,4 @@ if __name__ == "__main__":
         hd.update(data=data)
         hd.phase_to_time(np.median(hd.time_array))
         outname = os.path.basename(filename).replace('uvh5', f'{out}.uvfits')
-        hd.write_uvfits(os.path.join(.outdir, outname), spoof_nonessential=True)
+        hd.write_uvfits(os.path.join(a.outdir, outname), spoof_nonessential=True)

--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -60,14 +60,12 @@ if __name__ == "__main__":
     if len(model_files) == 0:
         sys.exit(0)
 
-    # load model
+    # load model for selected times only
     uvm = UVData()
-    uvm.read(model_files)
-
-    # down select on lsts
+    uvm.read(model_files, read_data=False)
     uvm_lsts = np.unwrap(np.unique(uvm.lst_array))
     tinds = (uvm_lsts > lst_bounds[0]) & (uvm_lsts < lst_bounds[1])
-    uvm.select(times=np.unique(uvm.time_array)[tinds])
+    uvm.read(model_files, times=np.unique(uvm.time_array)[tinds])
 
     # expand to data baselines
     data_bls = uvd.get_antpairpols()

--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -61,12 +61,14 @@ if __name__ == "__main__":
     if len(model_files) == 0:
         sys.exit(0)
 
-    # load model for selected times only
+    # load model
     uvm = UVData()
-    uvm.read(model_files, read_data=False)
+    uvm.read(model_files)
+
+    # down select on lsts
     uvm_lsts = np.unwrap(np.unique(uvm.lst_array))
-    tinds = (uvm_lsts > lst_bounds[0]) & (uvm_lsts < lst_bounds[1])
-    uvm.read(model_files, times=np.unique(uvm.time_array)[tinds])
+    tinds = (uvm_lsts >= lst_bounds[0]) & (uvm_lsts <= lst_bounds[1])
+    uvm.select(times=np.unique(uvm.time_array)[tinds])
 
     # expand to data baselines
     data_bls = uvd.get_antpairpols()


### PR DESCRIPTION
This PR improves the memory efficiency of get_model_vis.py (by loading less data simultaneously and copying less). 

This PR also imports a bunch of functionality from `hera_cal.abscal` for matching times and baselines in a more consistent way that was being done here. This turned out to be necessary for handling some of the challenges of the H1C abscal model, which doesn't quite have complete LST coverage, etc.