### PR TITLE
add env setting.

### DIFF
--- a/scripts/get_model_vis.py
+++ b/scripts/get_model_vis.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from pyuvdata import UVData, utils as uvutils
 import numpy as np
 import argparse

--- a/scripts/plot_fits.py
+++ b/scripts/plot_fits.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
@@ -82,7 +83,7 @@ if __name__ == "__main__":
         tag = "{} polarization\n{:.1f} MHz".format(pols[i], freq/1e6)
         ax.text(0.03, 0.88, tag, fontsize=15, color='k', transform=ax.transAxes,
                 bbox=dict(boxstyle='square', fc='w', ec='None', alpha=0.8, pad=.2))
- 
+
     fname = os.path.splitext(os.path.basename(a.filename))
     fname = os.path.join(a.outdir, fname[0] + '.png')
     fig.savefig(fname, dpi=100, bbox_inches='tight')


### PR DESCRIPTION
Added a line to one or two scripts so that they don't need to be called with `python <script-name>` which was having problems in makeflow. Why? For some reason, makeflow resets the python alias to `/opt/local/bin/python` so we have to call python scripts without python. It'd be a good idea to check that this doesn't break any H1C stuff. 